### PR TITLE
Add banned words

### DIFF
--- a/circleci/commit-lint
+++ b/circleci/commit-lint
@@ -17,7 +17,7 @@ class CommitLinter
     'docs', 'chore', 'bugfix', 'feature', 'refactor'
   ].freeze
   BANNED_WORDS = [
-    'fixup!', 'squash', 'wip'
+    'fixup', 'fixup!', 'squash', 'squash!', 'wip'
   ].freeze
 
   def self.call


### PR DESCRIPTION
My personal convention is to use `squash!` prefix when the commit title matches a previous commit to squash into. However, I'll use `squash` prefix when commit titles do not match a previous commit. The same goes for `fixup!` and `fixup`. This may not be a standard convention, but I have seen developers on our team use `fixup` instead of `fixup!` to address changes, so I think we'll want to add a couple banned words for commit linting to catch some of our prefered patterns for address review feedback.