### PR TITLE
[bugfix] incorrect `repo_url` when directory has different name

### DIFF
--- a/make-release
+++ b/make-release
@@ -16,7 +16,7 @@ tz = Time.now.getlocal.zone
 branch_name = "release/#{now}-#{tz}"
 
 if ENV['REPO_URL'].nil?
-  repo_name = `pwd`.chomp.split("/").last
+  repo_name = `basename -- $( git remote get-url origin )`.strip
   repo_url = "https://github.com/truecoach/#{repo_name}"
   puts "ENV['REPO_URL'] is not set. Falling back to #{repo_url}."
 else


### PR DESCRIPTION
When you change the name of the directory holding the repository the
`pwd` command cannot be relied upon to form the url. By using git's
internal tools to fetch the `repo_name` we can have better certainty the link
will be correct.

Note: we cannot use the git remote url directly as some people use ssh
urls for git remotes (e.g. ssh://git@github.com:truecoach/fitbot-server).

new command breakdown

basename - delete all prefixing information up to the last `/`
--       - denote that what follows are not options to the command
git remote get-url origin - the url of the origin remote